### PR TITLE
UTF8String type support

### DIFF
--- a/diameter-dictionary-parser.js
+++ b/diameter-dictionary-parser.js
@@ -202,6 +202,7 @@ var resolveToBaseType = function(type, appId) {
     if (type == 'Address') return 'OctetString';
     var parsableTypes = [
         'OctetString',
+        'UTF8String',
         'Unsigned32',
         'Integer32',
         'Unsigned64',

--- a/diameter-dictionary-parser.js
+++ b/diameter-dictionary-parser.js
@@ -196,10 +196,12 @@ var getTypedefn = function(type, appId) {
 };
 
 var resolveToBaseType = function(type, appId) {
-    if (type == 'QoSFilterRule') return 'OctetString';
+    if (type == 'QoSFilterRule') return 'UTF8String';
     if (type == 'Float32') return 'Unsigned32';
     if (type == 'Float64') return 'Unsigned64';
     if (type == 'Address') return 'OctetString';
+    if (type == 'DiameterIdentity') return 'UTF8String';
+    if (type == 'IPFilterRule') return 'UTF8String';
     var parsableTypes = [
         'OctetString',
         'UTF8String',


### PR DESCRIPTION
Some OctetString AVPs may contain raw binary data (e.g. Visited-PLMN-Id, E-UTRAN vectors fields like RAND, XRES, etc.) and shouldn't be interpreted as UTF-8.

Adding awareness of UTF8String type and also correcting the interpretation of some OctetString fields as UTF8String (not based on their parent types).